### PR TITLE
post-process successful CQL statement executions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
 		<encoding>UTF-8</encoding>
 		<scala.version>2.11.7</scala.version>
 		<gatling.version>2.1.7</gatling.version>
+		<cassandra-driver.version>2.1.8</cassandra-driver.version>
 	</properties>
 
 	<dependencies>
@@ -24,7 +25,7 @@
 		<dependency>
 			<groupId>com.datastax.cassandra</groupId>
 			<artifactId>cassandra-driver-core</artifactId>
-			<version>2.1.8</version>
+			<version>${cassandra-driver.version}</version>
 			<exclusions>
 				<!-- Provided by Gatling -->
 				<exclusion>

--- a/src/main/scala/io/github/gatling/cql/CqlAttributes.scala
+++ b/src/main/scala/io/github/gatling/cql/CqlAttributes.scala
@@ -24,5 +24,7 @@ package io.github.gatling.cql
 
 import com.datastax.driver.core.ConsistencyLevel
 
-case class CqlAttributes(tag: String, statement: CqlStatement, cl:ConsistencyLevel = ConsistencyLevel.ONE, checks: List[CqlCheck] = List.empty[CqlCheck])
+case class CqlAttributes(tag: String, statement: CqlStatement, cl:ConsistencyLevel = ConsistencyLevel.ONE,
+                         checks: List[CqlCheck] = List.empty[CqlCheck],
+                         postProcessors: List[CqlPostProcess] = List.empty[CqlPostProcess])
 

--- a/src/main/scala/io/github/gatling/cql/CqlRequestAction.scala
+++ b/src/main/scala/io/github/gatling/cql/CqlRequestAction.scala
@@ -55,7 +55,7 @@ class CqlRequestAction(val next: ActorRef, protocol: CqlProtocol, attr: CqlAttri
     stmt.map{ stmt =>
       stmt.setConsistencyLevel(attr.cl)
       val result = protocol.session.executeAsync(stmt)
-      Futures.addCallback(result, new CqlResponseHandler(next, session, start, attr.tag, stmt, attr.checks), CqlRequestAction.executor)
+      Futures.addCallback(result, new CqlResponseHandler(next, session, start, attr.tag, stmt, attr.checks, attr.postProcessors), CqlRequestAction.executor)
     }
   }
 }

--- a/src/main/scala/io/github/gatling/cql/CqlRequestBuilder.scala
+++ b/src/main/scala/io/github/gatling/cql/CqlRequestBuilder.scala
@@ -23,9 +23,7 @@
 package io.github.gatling.cql
 
 import com.datastax.driver.core.PreparedStatement
-import com.datastax.driver.core.SimpleStatement
 import com.datastax.driver.core.ConsistencyLevel
-import com.datastax.driver.core.ResultSet
 
 import io.gatling.core.action.builder.ActionBuilder
 import io.gatling.core.session.Expression
@@ -43,5 +41,6 @@ case class CqlRequestParamsBuilder(tag: String, prepared: PreparedStatement) {
 case class CqlRequestBuilder(attr: CqlAttributes) {
     def consistencyLevel(level: ConsistencyLevel) = CqlRequestBuilder(attr.copy(cl= level))
     def check(check: CqlCheck) = CqlRequestBuilder(attr.copy(checks = check :: attr.checks))
+    def postProcess(postProcess: CqlPostProcess) = CqlRequestBuilder(attr.copy(postProcessors = postProcess :: attr.postProcessors))
     def build(): ActionBuilder = new CqlRequestActionBuilder(attr)
 }

--- a/src/main/scala/io/github/gatling/cql/package.scala
+++ b/src/main/scala/io/github/gatling/cql/package.scala
@@ -23,9 +23,13 @@
 
 package io.github.gatling
 
+import io.gatling.core.session.Session
 import io.gatling.core.validation.Validation
-import com.datastax.driver.core.ResultSet
+import com.datastax.driver.core.{Statement, ResultSet}
 
 package object cql {
   type CqlCheck = ResultSet => Validation[Boolean]
+  type CqlPostProcess = CqlProcessed => Session
 }
+
+case class CqlProcessed(session: Session, tag: String, stmt: Statement, result: ResultSet, requestStartDate: Long, requestEndDate: Long)

--- a/src/test/scala/io/github/gatling/cql/CqlCompileTest.scala
+++ b/src/test/scala/io/github/gatling/cql/CqlCompileTest.scala
@@ -67,6 +67,14 @@ class CqlCompileTest extends Simulation {
           } else {
             Success(true)
           }
+        }
+        .postProcess {
+          param => {
+            if (!param.result.isExhausted)
+              param.session.set("row-of-" + param.tag, param.result.one().getInt("num"))
+            else
+              param.session
+          }
         })
     .exec(cql("prepared INSERT")
         .execute(prepared)


### PR DESCRIPTION
This allows extraction and evaluation of data from the result set and conditional execution of further requests by adding information to the Gatling session.

```
  val simpleSelect = cql("simple SELECT")
    .execute("SELECT * FROM test_table WHERE num = ${randomNum}")
    .postProcess( param => param.session.set("foo", param.result.one().getInt("num")) )

...

    feed(feeder)
      .exec(simpleSelect)
      .doIf("${foo}", "42") {
        exec( session => { println("Got 42")
          session } )
      }

```
