### PR TITLE
Thread pool replacement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ build.log
 build.log
 .cache-main
 .cache-tests
+
+#release files
+pom.xml.releaseBackup
+release.properties

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <scala.version>2.11.8</scala.version>
         <gatling.version>2.2.1</gatling.version>
         <gatling.maven-plugin.version>2.2.0</gatling.maven-plugin.version>
-        <cassandra-driver.version>3.0.2</cassandra-driver.version>
+        <cassandra-driver.version>3.1.1</cassandra-driver.version>
     </properties>
 
     <dependencies>

--- a/src/main/scala/io/github/gatling/cql/request/CqlRequestActionBuilder.scala
+++ b/src/main/scala/io/github/gatling/cql/request/CqlRequestActionBuilder.scala
@@ -31,6 +31,6 @@ class CqlRequestActionBuilder(attr: CqlAttributes) extends ActionBuilder with Na
 
   def build(ctx: ScenarioContext, next: Action): Action = {
     val cqlProtocol = ctx.protocolComponentsRegistry.protocols.protocol[CqlProtocol].getOrElse(throw new UnsupportedOperationException("CQL protocol wasn't registered"))
-    new CqlRequestAction(genName("CQL:" + attr.tag), next, ctx.coreComponents.statsEngine, cqlProtocol, attr)
+    new CqlRequestAction(genName("CQL:" + attr.tag), next, ctx.system, ctx.coreComponents.statsEngine, cqlProtocol, attr)
   }
 }

--- a/src/main/scala/io/github/gatling/cql/request/CqlRequestBuilder.scala
+++ b/src/main/scala/io/github/gatling/cql/request/CqlRequestBuilder.scala
@@ -32,12 +32,12 @@ import io.github.gatling.cql.checks.CqlCheck
 
 
 case class CqlRequestBuilderBase(tag: String) {
-  def execute(statement: Expression[String]) = new CqlRequestBuilder(CqlAttributes(tag, SimpleCqlStatement(statement)))
-  def execute(prepared: PreparedStatement) = new CqlRequestParamsBuilder(tag, prepared)
+  def execute(statement: Expression[String]) = CqlRequestBuilder(CqlAttributes(tag, SimpleCqlStatement(statement)))
+  def execute(prepared: PreparedStatement) = CqlRequestParamsBuilder(tag, prepared)
 }
 
 case class CqlRequestParamsBuilder(tag: String, prepared: PreparedStatement) {
-  def withParams(params: Expression[AnyRef]*) = new CqlRequestBuilder(CqlAttributes(tag, BoundCqlStatement(prepared, params:_*)))
+  def withParams(params: Expression[AnyRef]*) = CqlRequestBuilder(CqlAttributes(tag, BoundCqlStatement(prepared, params: _*)))
 }
 
 case class CqlRequestBuilder(attr: CqlAttributes) {

--- a/src/test/scala/io/github/gatling/cql/CqlRequestActionSpec.scala
+++ b/src/test/scala/io/github/gatling/cql/CqlRequestActionSpec.scala
@@ -22,38 +22,34 @@
  */
 package io.github.gatling.cql
 
-import io.github.gatling.cql.checks.CqlCheck
-import io.github.gatling.cql.request.{CqlAttributes, CqlProtocol, CqlRequestAction}
-import org.easymock.{Capture, EasyMock}
-import org.easymock.EasyMock.{anyObject, anyString, capture, reset, eq => eqAs}
-import org.scalatest.BeforeAndAfter
-import org.scalatest.FlatSpec
-import org.scalatest.Matchers
-import org.scalatest.mock.EasyMockSugar
-import com.datastax.driver.core.ConsistencyLevel
-import com.datastax.driver.core.RegularStatement
-import com.datastax.driver.core.ResultSetFuture
-import com.datastax.driver.core.Session
-import com.datastax.driver.core.SimpleStatement
+import akka.actor.ActorSystem
+import com.datastax.driver.core._
 import io.gatling.commons.stats.KO
-import io.gatling.commons.validation.FailureWrapper
-import io.gatling.commons.validation.SuccessWrapper
+import io.gatling.commons.validation.{FailureWrapper, SuccessWrapper}
 import io.gatling.core.action.Action
 import io.gatling.core.config.GatlingConfiguration
 import io.gatling.core.session.{Session => GSession}
 import io.gatling.core.stats.StatsEngine
 import io.gatling.core.stats.message.ResponseTimings
+import io.github.gatling.cql.checks.CqlCheck
+import io.github.gatling.cql.request.{CqlAttributes, CqlProtocol, CqlRequestAction}
+import org.easymock.Capture
+import org.easymock.EasyMock.{anyObject, anyString, capture, reset, eq => eqAs}
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
+import org.scalatest.mock.EasyMockSugar
 
 class CqlRequestActionSpec extends FlatSpec with EasyMockSugar with Matchers with BeforeAndAfter {
   val config = GatlingConfiguration.loadForTest()
   val cassandraSession = mock[Session]
   val statement = mock[CqlStatement]
+  val system = mock[ActorSystem]
   val statsEngine = mock[StatsEngine]
   val nextAction = mock[Action]
   val session = GSession("scenario", 1)
 
   val target =
     new CqlRequestAction("some-name", nextAction,
+      system,
       statsEngine,
       CqlProtocol(cassandraSession),
       CqlAttributes("test", statement, ConsistencyLevel.ANY, ConsistencyLevel.SERIAL, List.empty[CqlCheck]))


### PR DESCRIPTION
@Mishail, do you have time to review?

The PR removes the thread pool and uses the one in `ActorSystem`.
Also fixes an issue that response times were wrongly measured (used `response-timestamp - nowMillis` instead of `response-timestamp - request-timestamp`).

Beside this, the PR adds a cosmetic change and an upgrade to the latest java-driver.